### PR TITLE
fix typo in tag example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install "avoidable_admissions @ git+https://github.com/LTHTR-DST/hdruk_avoid
 
 Additional installation options are described in the [documentation](https://lthtr-dst.github.io/hdruk_avoidable_admissions/).
 
-Replace `<release-name>` with the latest release version e.g. `v.0.1.0-alpha`.
+Replace `<release-name>` with the latest release version e.g. `v0.1.0-alpha`.
 Omit `<release-name>` to install the latest code in the repo.
 
 List of releases can be found here - <https://github.com/LTHTR-DST/hdruk_avoidable_admissions/releases>.


### PR DESCRIPTION
README has an extra period in the example tag